### PR TITLE
fix: Github Actions kept failing due to missing package

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,7 +77,7 @@ jobs:
     container: "docker.io/fedora:latest"
     steps:
       - name: "Install packages"
-        run: "dnf install -y ca-certificates curl file findutils idn2 make"
+        run: "dnf install -y ca-certificates curl file findutils gawk idn2 make"
       - name: "Checkout project"
         uses: "actions/checkout@v4"
       - name: "Test project"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -501,7 +501,7 @@ jobs:
     container: "docker.io/fedora:latest"
     steps:
       - name: "Install packages"
-        run: "dnf install -y ca-certificates curl file findutils idn2 make"
+        run: "dnf install -y ca-certificates curl file findutils gawk idn2 make"
       - name: "Checkout project"
         uses: "actions/checkout@v4"
       - name: "Build project"
@@ -641,7 +641,7 @@ jobs:
       image: "docker.io/fedora:latest"
     steps:
       - name: "Install packages"
-        run: "dnf install -y ca-certificates curl file findutils idn2 make"
+        run: "dnf install -y ca-certificates curl file findutils gawk idn2 make"
       - name: "Install packages (2nd stage)"
         run: "dnf install -y m4 rpm-build rpmdevtools rsync systemd"
       - name: "Checkout project"


### PR DESCRIPTION
## Summary

This PR fixes the failing GitHub Actions workflows by correcting the workflow YAML file.

## Changes

- Resolved the missing `awk` issue in `.github/workflows/main.yml`.
- Updated the `Install packages` step in the following jobs:
  - `test-fedora-latest`
  - `build-fedora-latest`
  - `package-rpm`

## Validation

- All GitHub Actions workflows now pass successfully.